### PR TITLE
Added a secure text input option

### DIFF
--- a/Demo/CustomItemView/CircleItemView.swift
+++ b/Demo/CustomItemView/CircleItemView.swift
@@ -10,6 +10,8 @@ import UIKit
 import PinCodeInputView
 
 final class CircleItemView: UIView, ItemType {
+	var isSecureText: Bool = false
+	
     
     var text: Character? = nil {
         didSet {

--- a/Demo/CustomItemView/PasswordItemView.swift
+++ b/Demo/CustomItemView/PasswordItemView.swift
@@ -10,6 +10,9 @@ import UIKit
 import PinCodeInputView
 
 final class PasswordItemView: UIView, ItemType {
+	
+	var isSecureText: Bool = false
+	
     
     var text: Character? = nil {
         didSet {

--- a/Demo/CustomItemView/UnderlineItemView.swift
+++ b/Demo/CustomItemView/UnderlineItemView.swift
@@ -10,6 +10,8 @@ import UIKit
 import PinCodeInputView
 
 final class UnderlineItemView: UIView, ItemType {
+	var isSecureText: Bool = false
+	
     
     var text: Character? = nil {
         didSet {

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -18,7 +18,8 @@ class ViewController: UIViewController {
         itemFactory: {
             return ItemView()
     },
-		autoresizes: true)
+		autoresizes: true,
+		isSecureText: true)
 
     // customize item view (underline)
 //    let pinCodeInputView: PinCodeInputView<UnderlineItemView> = .init(

--- a/PinCodeInputView/ItemType.swift
+++ b/PinCodeInputView/ItemType.swift
@@ -12,5 +12,6 @@ public protocol ItemType {
     
     var text: Character? { get set }
     var isHiddenCursor: Bool { get set }
+	var isSecureText: Bool {get set}
     func set(appearance: ItemAppearance)
 }

--- a/PinCodeInputView/ItemView.swift
+++ b/PinCodeInputView/ItemView.swift
@@ -19,7 +19,7 @@ public class ItemView: UIView, ItemType {
                 label.text = nil
                 return
             }
-            label.text = String(text)
+			label.text = isSecureText ? "*" : String(text)
         }
     }
     
@@ -33,6 +33,14 @@ public class ItemView: UIView, ItemType {
 			}
         }
     }
+	
+	public var isSecureText: Bool = false {
+		didSet {
+			if let text = text {
+				label.text = isSecureText ? "*" : String(text)
+			}
+		}
+	}
     
     public let label: UILabel = .init()
     public let cursor: UIView = .init()

--- a/PinCodeInputView/PinCodeInputView.swift
+++ b/PinCodeInputView/PinCodeInputView.swift
@@ -37,6 +37,12 @@ public class PinCodeInputView<T: UIView & ItemType>: UIControl, UITextInputTrait
     override public var intrinsicContentSize: CGSize {
         return stackView.bounds.size
     }
+	
+	public var isSecureText: Bool = false {
+		didSet {
+			self.items.forEach({$0.itemView.isSecureText = self.isSecureText})
+		}
+	}
 
     private let digit: Int
     private let itemSpacing: CGFloat
@@ -63,7 +69,8 @@ public class PinCodeInputView<T: UIView & ItemType>: UIControl, UITextInputTrait
         digit: Int,
         itemSpacing: CGFloat,
         itemFactory: @escaping (() -> T),
-		autoresizes: Bool = false) {
+		autoresizes: Bool = false,
+		isSecureText: Bool = false) {
         
         self.digit = digit
         self.itemSpacing = itemSpacing
@@ -79,10 +86,12 @@ public class PinCodeInputView<T: UIView & ItemType>: UIControl, UITextInputTrait
             }
             return item
         }
+		self.isSecureText = isSecureText
         self.stackView.frame = self.bounds
         addSubview(stackView)
         
         items.forEach { stackView.addArrangedSubview($0) }
+		items.forEach({$0.itemView.isSecureText = self.isSecureText})
         stackView.spacing = itemSpacing
         stackView.axis = .horizontal
         stackView.distribution = .fillEqually


### PR DESCRIPTION
You are now able to show text as secure input. The way to do it is to set the ```isSecureText``` field in the ```PinCodeInputView``` to true. As well, all ItemViews will now have a ```isSecureText``` field.